### PR TITLE
support finish command specify target branch

### DIFF
--- a/bin/git-solo-flow
+++ b/bin/git-solo-flow
@@ -99,6 +99,11 @@ start(){
 
 finish(){
 	BRANCH=${1:-$CUR_BRANCH}
+	MASTER=${2:-$MASTER}
+	if [ $BRANCH = "." ]; then
+		BRANCH="$CUR_BRANCH"
+	fi
+
 	_require_local_branch_exists $BRANCH
 
 	BRANCH_UPSTREAM=$(_lookup_upstream $BRANCH)


### PR DESCRIPTION
Usage: `git solo-flow finish . TARGET_BRANCH` 
`.` means current branch
